### PR TITLE
Potential fix for code scanning alert no. 3: Reflected cross-site scripting

### DIFF
--- a/cmd/lol-utils/main.go
+++ b/cmd/lol-utils/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"embed"
 	"fmt"
+	"html"
 	"net/http"
 	"os"
 	"strings"
@@ -37,7 +38,7 @@ func (h *FileLoader) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	absPath, err := filepath.Abs(filepath.Join(safeDir, requestedFilename))
 	if err != nil || !strings.HasPrefix(absPath, safeDir) {
 		res.WriteHeader(http.StatusBadRequest)
-		res.Write([]byte(fmt.Sprintf("Invalid file path: %s", requestedFilename)))
+		res.Write([]byte(fmt.Sprintf("Invalid file path: %s", html.EscapeString(requestedFilename))))
 		return
 	}
 	


### PR DESCRIPTION
Potential fix for [https://github.com/fudio101/lol-utils/security/code-scanning/3](https://github.com/fudio101/lol-utils/security/code-scanning/3)

To fix the issue, the user-controlled input (`requestedFilename`) should be sanitized or escaped before being included in the HTTP response. In Go, the `html.EscapeString` function from the `html` package is a standard way to escape special characters in a string to make it safe for inclusion in HTML content. This will prevent any malicious scripts from being executed if the response is rendered in a browser.

The fix involves:
1. Importing the `html` package.
2. Escaping the `requestedFilename` variable using `html.EscapeString` before including it in the response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
